### PR TITLE
Use `Clamp` function from `Mathf`, cast `short`

### DIFF
--- a/Assets/Scripts/FFBManager.cs
+++ b/Assets/Scripts/FFBManager.cs
@@ -105,7 +105,8 @@ public class FFBManager : MonoBehaviour
             }
             
             //The value we to pass is where 0 is full movement flexibility, so invert.
-            fingerCurlAverages[i] = Math.Clamp(Convert.ToInt16(1000 - (Mathf.FloorToInt(enumerator / fingerCurlValues[i].Count * 1000))), (short)0, (short)1000);
+            fingerCurlAverages[i] = (short)Mathf.Clamp(Convert.ToInt16(1000 - (Mathf.FloorToInt(enumerator / fingerCurlValues[i].Count * 1000))), (short)0, (short)1000);
+
             
             Debug.Log(fingerCurlAverages[i]);
         }


### PR DESCRIPTION
This doesn't compile in Unity 2020.3.41f1, I think because the flat `Math` library in `System` doesn't have Clamp, so I changed it to `Mathf`.